### PR TITLE
Fix cabal file, closes #6

### DIFF
--- a/atomic-write.cabal
+++ b/atomic-write.cabal
@@ -85,7 +85,6 @@ test-suite atomic-write-test
                      , atomic-write
                      , temporary
                      , unix-compat
-                     , directory
                      , filepath
                      , text
                      , bytestring >= 0.10.4

--- a/atomic-write.cabal
+++ b/atomic-write.cabal
@@ -68,7 +68,8 @@ library
 
   hs-source-dirs:      src
   default-language:    Haskell2010
-  ghc-options:         -Wall
+  ghc-options:         -Wall -Werror
+
 
 test-suite atomic-write-test
   type: exitcode-stdio-1.0
@@ -91,7 +92,7 @@ test-suite atomic-write-test
                      , hspec
 
   default-language:    Haskell2010
-  ghc-options:         -Wall
+  ghc-options:         -Wall -Werror
 
 
 source-repository head

--- a/atomic-write.cabal
+++ b/atomic-write.cabal
@@ -72,10 +72,17 @@ library
 
 test-suite atomic-write-test
   type: exitcode-stdio-1.0
-  hs-source-dirs: spec, src
+  hs-source-dirs: spec
   main-is: Spec.hs
 
+  other-modules:       System.AtomicWrite.Writer.ByteStringSpec
+                     , System.AtomicWrite.Writer.ByteStringBuilderSpec
+                     , System.AtomicWrite.Writer.LazyByteStringSpec
+                     , System.AtomicWrite.Writer.StringSpec
+                     , System.AtomicWrite.Writer.TextSpec
+
   build-depends:       base >= 4.5 && < 5.0
+                     , atomic-write
                      , temporary
                      , unix-compat
                      , directory


### PR DESCRIPTION
### Add other modules to test suite

- Add spec modules to the test suite.
- Add atomic-write library as a build dependency of the test suite.

Solves #6.