### PR TITLE
Add missing documentation for module headers

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2015 Justin Leitgeb
+Copyright (c) 2015-2017 Justin Leitgeb
 
 Permission is hereby granted, free of charge, to any person obtaining
 a copy of this software and associated documentation files (the

--- a/README.md
+++ b/README.md
@@ -21,4 +21,4 @@ MIT
 
 ## Copyright
 
-(C) 2015 [Stack Builders Inc.](http://www.stackbuilders.com/)
+(C) 2015-2017 [Stack Builders Inc.](http://www.stackbuilders.com/)

--- a/atomic-write.cabal
+++ b/atomic-write.cabal
@@ -43,7 +43,7 @@ license:             MIT
 license-file:        LICENSE
 author:              Justin Leitgeb
 maintainer:          justin@stackbuilders.com
-copyright:           2015 Stack Builders Inc.
+copyright:           2015-2017 Stack Builders Inc.
 category:            System
 build-type:          Simple
 cabal-version:       >=1.10

--- a/src/System/AtomicWrite/Internal.hs
+++ b/src/System/AtomicWrite/Internal.hs
@@ -1,3 +1,15 @@
+-- |
+-- Module      :  Configuration.Dotenv.Parse
+-- Copyright   :  © 2015-2017 Stack Builders Inc.
+-- License     :  MIT
+--
+-- Maintainer  :  Stack Builders <hackage@stackbuilders.com>
+-- Stability   :  experimental
+-- Portability :  portable
+--
+-- Provides functionality to create a temporary file with correct permissions
+-- atomically.
+
 module System.AtomicWrite.Internal (closeAndRename, tempFileFor) where
 
 import System.Directory (doesFileExist, renameFile)

--- a/src/System/AtomicWrite/Writer/ByteString.hs
+++ b/src/System/AtomicWrite/Writer/ByteString.hs
@@ -1,3 +1,15 @@
+-- |
+-- Module      :  Configuration.Dotenv.Parse
+-- Copyright   :  © 2015-2017 Stack Builders Inc.
+-- License     :  MIT
+--
+-- Maintainer  :  Stack Builders <hackage@stackbuilders.com>
+-- Stability   :  experimental
+-- Portability :  portable
+--
+-- Provides functionality to dump the contents of a ByteString
+-- to a file.
+
 module System.AtomicWrite.Writer.ByteString (atomicWriteFile) where
 
 import System.AtomicWrite.Internal (closeAndRename, tempFileFor)

--- a/src/System/AtomicWrite/Writer/ByteStringBuilder.hs
+++ b/src/System/AtomicWrite/Writer/ByteStringBuilder.hs
@@ -1,3 +1,15 @@
+-- |
+-- Module      :  Configuration.Dotenv.Parse
+-- Copyright   :  © 2015-2017 Stack Builders Inc.
+-- License     :  MIT
+--
+-- Maintainer  :  Stack Builders <hackage@stackbuilders.com>
+-- Stability   :  experimental
+-- Portability :  portable
+--
+-- Provides functionality to dump the contents of a ByteStringBuilder
+-- to a file.
+
 module System.AtomicWrite.Writer.ByteStringBuilder (atomicWriteFile) where
 
 import System.AtomicWrite.Internal (closeAndRename, tempFileFor)

--- a/src/System/AtomicWrite/Writer/LazyByteString.hs
+++ b/src/System/AtomicWrite/Writer/LazyByteString.hs
@@ -1,3 +1,15 @@
+-- |
+-- Module      :  Configuration.Dotenv.Parse
+-- Copyright   :  © 2015-2017 Stack Builders Inc.
+-- License     :  MIT
+--
+-- Maintainer  :  Stack Builders <hackage@stackbuilders.com>
+-- Stability   :  experimental
+-- Portability :  portable
+--
+-- Provides functionality to dump the contents of a Lazy ByteString
+-- to a file.
+
 module System.AtomicWrite.Writer.LazyByteString (atomicWriteFile) where
 
 import System.AtomicWrite.Internal (closeAndRename, tempFileFor)

--- a/src/System/AtomicWrite/Writer/String.hs
+++ b/src/System/AtomicWrite/Writer/String.hs
@@ -1,3 +1,15 @@
+-- |
+-- Module      :  Configuration.Dotenv.Parse
+-- Copyright   :  © 2015-2017 Stack Builders Inc.
+-- License     :  MIT
+--
+-- Maintainer  :  Stack Builders <hackage@stackbuilders.com>
+-- Stability   :  experimental
+-- Portability :  portable
+--
+-- Provides functionality to dump the contents of a String
+-- to a file.
+
 module System.AtomicWrite.Writer.String (atomicWriteFile, atomicWithFile) where
 
 import System.AtomicWrite.Internal (closeAndRename, tempFileFor)

--- a/src/System/AtomicWrite/Writer/Text.hs
+++ b/src/System/AtomicWrite/Writer/Text.hs
@@ -1,3 +1,15 @@
+-- |
+-- Module      :  Configuration.Dotenv.Parse
+-- Copyright   :  © 2015-2017 Stack Builders Inc.
+-- License     :  MIT
+--
+-- Maintainer  :  Stack Builders <hackage@stackbuilders.com>
+-- Stability   :  experimental
+-- Portability :  portable
+--
+-- Provides functionality to dump the contents of a Text
+-- to a file.
+
 module System.AtomicWrite.Writer.Text (atomicWriteFile) where
 
 import System.AtomicWrite.Internal (closeAndRename, tempFileFor)


### PR DESCRIPTION
This pull request resolves the issue #7.
It also updates the _copyright_ year used in the application from 2015 to 2015-2017.