### PR TITLE
Add boundaries for dependencies in cabal file

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,6 +16,7 @@ jobs:
         ghc:
           - "8.10"
           - "8.4.3"
+          - "9.4.7"
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/atomic-write.cabal
+++ b/atomic-write.cabal
@@ -67,9 +67,9 @@ library
   build-depends:         base >= 4.5 && < 5.0
                        , temporary >= 1.3 && < 1.4
                        , unix-compat >= 0.7 && < 1.0
-                       , directory >= 1.0 && < 1.4
+                       , directory >= 1.3 && < 1.4
                        , filepath >= 1.4 && < 1.5
-                       , text >= 2.0 && < 3.0
+                       , text >= 2.1 && < 3.0
                        , bytestring >= 0.10.4 && < 0.13.0
 
   hs-source-dirs:      src
@@ -96,11 +96,11 @@ test-suite atomic-write-test
 
   build-depends:       base >= 4.5 && < 5.0
                      , atomic-write
-                     , temporary >= 1.3 && < 1.4
-                     , unix-compat >= 0.7 && < 1.0
-                     , filepath >= 1.4 && < 1.5
-                     , text >= 2.0 && < 3.0
-                     , bytestring >= 0.10.4 && < 0.13.0
+                     , temporary
+                     , unix-compat
+                     , filepath
+                     , text
+                     , bytestring
                      , hspec
 
   build-tools: hspec-discover >= 2.0 && < 3.0

--- a/atomic-write.cabal
+++ b/atomic-write.cabal
@@ -96,11 +96,11 @@ test-suite atomic-write-test
 
   build-depends:       base >= 4.5 && < 5.0
                      , atomic-write
-                     , temporary
-                     , unix-compat
-                     , filepath
-                     , text
-                     , bytestring >= 0.10.4
+                     , temporary >= 1.3 && < 1.4
+                     , unix-compat >= 0.7 && < 1.0
+                     , filepath >= 1.4 && < 1.5
+                     , text >= 2.0 && < 3.0
+                     , bytestring >= 0.10.4 && < 0.13.0
                      , hspec
 
   build-tools: hspec-discover >= 2.0 && < 3.0

--- a/atomic-write.cabal
+++ b/atomic-write.cabal
@@ -65,12 +65,12 @@ library
   other-modules:       System.AtomicWrite.Internal
 
   build-depends:         base >= 4.5 && < 5.0
-                       , temporary
-                       , unix-compat
-                       , directory
-                       , filepath
-                       , text
-                       , bytestring >= 0.10.4
+                       , temporary >= 1.3 && < 1.4
+                       , unix-compat >= 0.7 && < 1.0
+                       , directory >= 1.0 && < 1.4
+                       , filepath >= 1.4 && < 1.5
+                       , text >= 2.0 && < 3.0
+                       , bytestring >= 0.10.4 && < 0.13.0
 
   hs-source-dirs:      src
   default-language:    Haskell2010


### PR DESCRIPTION
This PR add boundaries to the project dependencies.
The added boundaries are based on the base boundary and the general use of other dependencies with each other.

Solves #36 