### PR TITLE
chore(ci): update cabal upload for docs job

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -60,6 +60,7 @@ jobs:
       - name: Upload documentation to Hackage
         run: |
           cabal upload --publish \
-            --token "${{ secrets.HACKAGE_API_KEY }}"
+            --username "${{ secrets.HACKAGE_USERNAME }}" \
+            --password "${{ secrets.HACKAGE_PASSWORD }}" \
             --documentation \
             dist-newstyle/*-docs.tar.gz


### PR DESCRIPTION
Updated the `cabal upload` job in the release workflow for using `username` and `password` because `token` is not working.