### PR TITLE
Added `kleidukos/get-tested action` to generate CI matrix

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,14 +11,26 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  haskell:
-    strategy:
-      matrix:
-        ghc:
-          - "8.10"
-          - "8.4.3"
-          - "9.4.7"
+  generate-matrix:
+    name: "Generate matrix from cabal"
+    outputs:
+      matrix: ${{ steps.set-matrix.outputs.matrix }}
     runs-on: ubuntu-latest
+    steps:
+      - name: Extract the tested GHC versions
+        id: set-matrix
+        uses: kleidukos/get-tested@v0.1.7.0
+        with:
+          cabal-file: atomic-write.cabal
+          ubuntu-version: latest
+          version: 0.1.7.0
+
+  build-and-test:
+    name: GHC ${{ matrix.ghc }} on ${{ matrix.os }}
+    needs: generate-matrix
+    strategy:
+      matrix: ${{ fromJSON(needs.generate-matrix.outputs.matrix) }}
+    runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/atomic-write.cabal
+++ b/atomic-write.cabal
@@ -47,6 +47,9 @@ copyright:           2015-2019 Stack Builders Inc.
 category:            System
 build-type:          Simple
 cabal-version:       >=1.10
+tested-with:
+  GHC ==8.4.3, GHC ==8.10.7, GHC ==9.4.7
+
 bug-reports:         https://github.com/stackbuilders/atomic-write/issues
 
 library


### PR DESCRIPTION
Thanks to the [get-tested](https://github.com/Kleidukos/get-tested) action, we can automatically generate the matrix of GHC versions to run the CI on. This keeps the tested-with versions we set in Cabal files accurate to what is actually being tested in the CI. 

Since `atomic-write` was missing the `tested-with` stanza in its Cabal file, I also added that.