### PR TITLE
Allow filepath-1.5 series

### DIFF
--- a/atomic-write.cabal
+++ b/atomic-write.cabal
@@ -71,7 +71,7 @@ library
                        , temporary >= 1.3 && < 1.4
                        , unix-compat >= 0.5 && < 1.0
                        , directory >= 1.3 && < 1.4
-                       , filepath >= 1.4 && < 1.5
+                       , filepath >= 1.4 && < 1.6
                        , text >= 1.2 && < 3.0
                        , bytestring >= 0.10.4 && < 0.13.0
 


### PR DESCRIPTION
Fix #56.

Tested using `cabal test --enable-tests -c 'filepath>=1.5'`
