### PR TITLE
Bump patch version to 2.0.8 for filepath dependency update

### DIFF
--- a/atomic-write.cabal
+++ b/atomic-write.cabal
@@ -1,5 +1,5 @@
 name:                atomic-write
-version:             0.2.0.7
+version:             0.2.0.8
 synopsis:            Atomically write to a file
 homepage:            https://github.com/stackbuilders/atomic-write
 description:


### PR DESCRIPTION
Bump patch version to allow for filepath dependency update fix. See: https://github.com/stackbuilders/atomic-write/pull/57