### PR TITLE
fix(docs): minor update to docs - trigger release for boundary updates

### DIFF
--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -5,6 +5,8 @@ Thank you for your interest in contributing to this Stack Builders' library. To 
 
 - Once the change has been discussed with the maintainer(s), feel free to open a Pull Request. Please include a link to the issue you're trying to solve, or a quick summary of the discussed changes.
 
+- This repo makes use of [semantic-release](https://github.com/semantic-release/semantic-release) with the [semantic-release-hackage](https://github.com/stackbuilders/semantic-release-hackage) puglin. PRs and commits should be following conventional commits formating to properly capture expected changes and determine the version to release.
+
 - If adding any new features that you think should be considered in the README file, please add that information in your Pull Request.
 
 - Once you get an approval from any of the maintainers, please merge your Pull Request. Keep in mind that some of our Stack Builders repositories use CI/CD pipelines, so you will need to pass all of the required checks before merging.


### PR DESCRIPTION
This PR does two things:
- It makes a minor changes in the contributing guidelines in relation to how commits and PRs should be named. A bigger update will be commit with more details to this approach, and possibly check to ensure that all PRs are merged with the proper commit naming standard.
- It also puts its PR as a fix, instead of a chore, so we can trigger a release of previous changes made in relation to some boundary updates. Some additional work will be needed to increase the range of boundaries we are testing with.